### PR TITLE
Fix deprecated warnings in Haxe 4.0

### DIFF
--- a/src/pako/Deflate.hx
+++ b/src/pako/Deflate.hx
@@ -1,8 +1,13 @@
 package pako;
 
 import pako.Pako;
+#if haxe4
+import js.lib.Uint8Array;
+import js.lib.ArrayBuffer;
+#else
 import js.html.Uint8Array;
 import js.html.ArrayBuffer;
+#end
 import haxe.extern.EitherType;
 
 typedef GZIPHeader = {

--- a/src/pako/Inflate.hx
+++ b/src/pako/Inflate.hx
@@ -1,8 +1,13 @@
 package pako;
 
 import pako.Pako;
+#if haxe4
+import js.lib.Uint8Array;
+import js.lib.ArrayBuffer;
+#else
 import js.html.Uint8Array;
 import js.html.ArrayBuffer;
+#end
 import haxe.extern.EitherType;
 
 typedef InflateOptions = {

--- a/src/pako/Pako.hx
+++ b/src/pako/Pako.hx
@@ -1,7 +1,12 @@
 package pako;
 
+#if haxe4
+import js.lib.Uint8Array;
+import js.lib.ArrayBuffer;
+#else
 import js.html.Uint8Array;
 import js.html.ArrayBuffer;
+#end
 import pako.Deflate.DeflateOptions;
 import pako.Inflate.InflateOptions;
 import haxe.extern.EitherType;


### PR DESCRIPTION
Fix these warnings:

```
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:9: characters 33-43 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:9: characters 56-67 : Warning : This typedef is deprecated in favor of js.lib.ArrayBuffer
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:52: characters 27-37 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:52: characters 64-74 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:59: characters 27-37 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:59: characters 64-74 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:66: characters 27-37 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:66: characters 64-74 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:82: characters 27-37 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:82: characters 64-74 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:89: characters 27-37 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:89: characters 64-74 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:96: characters 27-37 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Pako.hx:96: characters 64-74 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Inflate.hx:57: characters 28-38 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Inflate.hx:86: characters 27-37 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Inflate.hx:88: characters 27-38 : Warning : This typedef is deprecated in favor of js.lib.ArrayBuffer
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Deflate.hx:72: characters 20-30 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Deflate.hx:80: characters 28-38 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Deflate.hx:109: characters 27-37 : Warning : This typedef is deprecated in favor of js.lib.Uint8Array
C:/HaxeToolkit/haxe/lib/pako/1,0,6/src/pako/Deflate.hx:111: characters 27-38 : Warning : This typedef is deprecated in favor of js.lib.ArrayBuffer
```